### PR TITLE
Use Province as source of geoms and relate to StratUnit

### DIFF
--- a/restapi/controller/stratnames.py
+++ b/restapi/controller/stratnames.py
@@ -45,3 +45,33 @@ ORDER BY ?btime
       "results": arr_strat,
    }
    return response, 200
+
+def get_stratunit_for_province(uri):
+   limit = 2000
+   offset = 0
+   sparql = """\
+PREFIX strat: <http://pid.geoscience.gov.au/def/stratname#>
+select ?stratunit 
+where {{
+	<{p_uri}> a strat:Province .
+    ?stratunit strat:relation <{p_uri}>
+}}
+""".format(p_uri=uri)
+   resp = query_graphdb_endpoint(sparql, limit=limit, offset=offset)
+   arr_strat = []
+   if 'results' not in resp:
+      return resp_object
+   bindings = resp['results']['bindings']
+   for b in bindings:
+      stratunit_uri = b['stratunit']['value']
+      arr_strat.append(stratunit_uri)
+   meta = {
+      'count': len(arr_strat),
+      'offset': offset,
+   }
+   response = {
+      "meta": meta,
+      "results": arr_strat,
+   }
+   return response, 200
+

--- a/restapi/openapi.yaml
+++ b/restapi/openapi.yaml
@@ -46,7 +46,7 @@ paths:
           content: {}
 
 
-  /stratnames:
+  /stratunit/:
     get:
       summary: Gets all stratnames
       tags:
@@ -56,6 +56,26 @@ paths:
         200:
           description: Success
           content: {}
+
+  /stratunit/province:
+    get:
+      tags:
+      - stratnames 
+      summary: Gets a stratunit for a province
+      operationId: controller.stratnames.get_stratunit_for_province
+      parameters:
+      - name: uri
+        in: query
+        description: Province URI
+        required: true
+        example:  "http://pid.geoscience.gov.au/dataset/stratnames/p20054"
+        schema:
+          type: string
+      responses:
+        200:
+          description: Success
+          content: {}
+
 
   /location/find_at_location:
     get:


### PR DESCRIPTION
This PR refactors the code of find-at-location to return province feature URI. It also adds and REST endpoint to allow users to get the Stratunit for a Province URI. This allows a workflow like so:

Input lat-long coord --> Return province geom and Province Feature URI --> Get StratUnit using Province Feature URI --> List StratUnits for each province feature.