### PR TITLE
add /location/find_stratunit_at_location

### DIFF
--- a/restapi/controller/location.py
+++ b/restapi/controller/location.py
@@ -83,3 +83,101 @@ select ?feature where {{
    for b in bindings:
       arr_features.append(b['feature']['value'])
    return arr_features
+
+def find_stratunit_at_location(lat, lon, crs=4326, count=1000, offset=0):
+    """
+    This function finds geometries for a given lat-long coord. 
+    It then queries the graphDB to workout which stratunits match based on 
+    apriori known datatype relationships with the geometry of the features.
+    :param lat:
+    :type lat: float
+    :param lon:
+    :type lon: float
+    :param crs:
+    :type crs: int
+    :param count:
+    :type count: int
+    :param offset:
+    :type offset: int
+    :return:
+    """
+    row = {}
+    results = {}
+    counter = 0
+    params = {
+       "_format" : "application/json",
+       "crs": crs
+    }
+    headers = {
+       "Accept" : "application/json"
+    }
+    formatted_resp = {
+        'ok': False
+    }
+    http_ok = [200]
+    search_by_latlng_url = GEOM_DATA_SVC_ENDPOINT + "/search/latlng/{},{}".format(lon,lat)
+    try:
+        resp = requests.get(search_by_latlng_url, params=params, headers=headers)
+        if resp.status_code not in http_ok:
+            formatted_resp['errorMessage'] = "Could not connect to the geometry data service at {}. Error code {}".format(GEOM_DATA_SVC_ENDPOINT, resp.status)
+            return formatted_resp
+        formatted_resp = resp.json()
+        formatted_resp['ok'] = True
+    except:
+        formatted_resp['errorMessage'] = "Could not connect to the geometry data service at {}. Error thrown.".format(GEOM_DATA_SVC_ENDPOINT)
+        return formatted_resp
+    r = formatted_resp['res']
+    del(formatted_resp['res'])
+    meta = formatted_resp
+    meta['offset'] = offset
+
+    #query triple store for the features with input geom
+    for geom_res in r:
+       dict_stratUnits = fetch_stratunit_for_geom(geom_res['geometry'], geom_res['id'],  geom_res['dataset'])
+       geom_res['features'] = dict_stratUnits 
+       geom_res.pop('feature') 
+
+    returned_resp = { "meta" : meta, "results": r }
+    return returned_resp, 200
+
+def fetch_stratunit_for_geom(geom_uri, local_id, dataset, limit=1000, offset=0):
+   the_geom_uri = geom_uri
+   arr_features = []
+   if dataset != 'province':
+      print("Don't know how to handle data that's not a province")
+      return []
+   #A Province has the geometry. A StratUnit hasRelation with Province
+   #So for now return both
+   ### TODO: Replace the following hacky solution
+   #the_geom_uri = geom_uri  ##Commenting this out for when the geom uri is stable. 
+   #use the id for now and build a URI
+   the_geom_uri = "https://gds.loci.cat/geometry/province/p{}".format(local_id)
+   sparql = """\
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX strat: <http://pid.geoscience.gov.au/def/stratname#>
+select ?province ?stratunit where {{
+    ?province geo:hasGeometry <{g_uri}> .
+    ?stratunit strat:relation ?province . 
+    ?stratunit a strat:Unit .
+    ?province a strat:Province
+}}
+""".format(g_uri=the_geom_uri)
+   resp = query_graphdb_endpoint(sparql, limit=limit, offset=offset)
+   if 'results' not in resp:
+      return resp_object
+   bindings = resp['results']['bindings']
+   dict_features = {}
+   for b in bindings:
+      curr_province = b['province']['value']
+      if curr_province not in dict_features:
+         dict_features[curr_province] = []
+      dict_features[curr_province].append(b['stratunit']['value'])
+
+   returned_obj = []
+   for p in dict_features:
+      o = {}
+      o['province'] = p
+      o['stratunit'] = dict_features[p]
+      returned_obj.append(o)
+   return returned_obj
+

--- a/restapi/openapi.yaml
+++ b/restapi/openapi.yaml
@@ -8,8 +8,8 @@ servers:
 tags:
 - name: default
   description: Default namespace
-- name: stratnames
-  description: Stratnames
+- name: stratunits
+  description: stratunits
 - name: loc-func
   description: Location
 
@@ -48,9 +48,9 @@ paths:
 
   /stratunit/:
     get:
-      summary: Gets all stratnames
+      summary: Gets all stratunits
       tags:
-      - stratnames 
+      - stratunits 
       operationId: controller.stratnames.get
       responses:
         200:
@@ -60,7 +60,7 @@ paths:
   /stratunit/province:
     get:
       tags:
-      - stratnames 
+      - stratunits 
       summary: Gets a stratunit for a province
       operationId: controller.stratnames.get_stratunit_for_province
       parameters:
@@ -82,7 +82,7 @@ paths:
       responses:
         '200':
           description: Success
-      summary: 'Finds all LOCI features that intersect with this location, specified by the coordinates'
+      summary: 'Finds all features that intersect with this location, specified by the coordinates'
       description: 'Note: count and offset do not currently work properly on /overlaps'
       operationId: controller.location.find_at_location
       parameters:
@@ -130,4 +130,59 @@ paths:
       security: []
       tags:
         - loc-func
+
+  /location/find_stratunit_at_location:
+    get:
+      responses:
+        '200':
+          description: Success
+      summary: 'Finds all StratUnit features that intersect with this location (via Provinces), specified by the coordinates'
+      description: 'Note: count and offset do not currently work properly on /overlaps'
+      operationId: controller.location.find_stratunit_at_location
+      parameters:
+        - name: lat
+          description: Query point latitude
+          required: true
+          example: -35.27
+          in: query
+          schema:
+            type: number
+            format: float            
+        - name: lon
+          required: true
+          in: query
+          example: 149.09
+          schema:
+            type: number
+            format: float
+        - name: crs
+          description: Query point CRS. Default is 4326 (WGS 84)
+          required: false
+          example: "4326"
+          schema:
+            default: "4326"
+            type: string
+          in: query
+        - description: Number of locations to return.
+          required: false
+          name: count
+          example: 1000
+          in: query
+          schema:
+            type: number
+            format: integer
+            default: 1000
+        - description: Skip number of locations before returning count.
+          required: false
+          name: offset
+          example: 0
+          in: query
+          schema:
+            type: number
+            format: integer
+            default: 0
+      security: []
+      tags:
+        - loc-func
+
 


### PR DESCRIPTION
Provides the `/location/find_stratunit_at_location` endpoint. Returns matching province geom, and stratunit for each province. e.g.

```
{
      "dataset": "province",
      "features": [
        {
          "province": "http://pid.geoscience.gov.au/dataset/stratnames/p20514",
          "stratunit": [
            "http://pid.geoscience.gov.au/dataset/stratnames/u98",
            "http://pid.geoscience.gov.au/dataset/stratnames/u1474",
            "http://pid.geoscience.gov.au/dataset/stratnames/u13338",
            "http://pid.geoscience.gov.au/dataset/stratnames/u31707",
            "http://pid.geoscience.gov.au/dataset/stratnames/u14578",
            "http://pid.geoscience.gov.au/dataset/stratnames/u20777",
            "http://pid.geoscience.gov.au/dataset/stratnames/u33678",
            "http://pid.geoscience.gov.au/dataset/stratnames/u1727",
            "http://pid.geoscience.gov.au/dataset/stratnames/u24002",
            "http://pid.geoscience.gov.au/dataset/stratnames/u29574",
            "http://pid.geoscience.gov.au/dataset/stratnames/u8277",
            "http://pid.geoscience.gov.au/dataset/stratnames/u27446",
            "http://pid.geoscience.gov.au/dataset/stratnames/u33382"
          ]
        }
      ],
      "geometry": "http://localhost:3000/geometry/province/20514",
      "id": 20514
    },
```