### PR TITLE
Correct API file to use integer as its own type as per OpenAPI spec

### DIFF
--- a/restapi/openapi.yaml
+++ b/restapi/openapi.yaml
@@ -115,8 +115,8 @@ paths:
           example: 1000
           in: query
           schema:
-            type: number
-            format: integer
+            type: integer
+            format: int32
             default: 1000
         - description: Skip number of locations before returning count.
           required: false
@@ -124,8 +124,8 @@ paths:
           example: 0
           in: query
           schema:
-            type: number
-            format: integer
+            type: integer
+            format: int32
             default: 0
       security: []
       tags:
@@ -169,8 +169,8 @@ paths:
           example: 1000
           in: query
           schema:
-            type: number
-            format: integer
+            type: integer
+            format: int32
             default: 1000
         - description: Skip number of locations before returning count.
           required: false
@@ -178,8 +178,8 @@ paths:
           example: 0
           in: query
           schema:
-            type: number
-            format: integer
+            type: integer
+            format: int32
             default: 0
       security: []
       tags:


### PR DESCRIPTION
The 'openapi.yaml' file needs fixing because specifying a format of  'integer' with type of 'number' causes this error:

Traceback (most recent call last):
  File "./app.py", line 14, in <module>
    app.add_api('openapi.yaml', resolver=RestyResolver('api'))
  File "/usr/local/lib/python3.6/site-packages/connexion/apps/flask_app.py", line 57, in add_api
    api = super(FlaskApp, self).add_api(specification, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/connexion/apps/abstract.py", line 156, in add_api
    options=api_options.as_dict())
  File "/usr/local/lib/python3.6/site-packages/connexion/apis/abstract.py", line 75, in __init__
    self.specification = Specification.load(specification, arguments=arguments)
  File "/usr/local/lib/python3.6/site-packages/connexion/spec.py", line 153, in load
    return cls.from_file(spec, arguments=arguments)
  File "/usr/local/lib/python3.6/site-packages/connexion/spec.py", line 107, in from_file
    return cls.from_dict(spec)
  File "/usr/local/lib/python3.6/site-packages/connexion/spec.py", line 145, in from_dict
    return OpenAPISpecification(spec)
  File "/usr/local/lib/python3.6/site-packages/connexion/spec.py", line 38, in __init__
    self._validate_spec(raw_spec)
  File "/usr/local/lib/python3.6/site-packages/connexion/spec.py", line 239, in _validate_spec
    raise InvalidSpecification.create_from(e)
connexion.exceptions.InvalidSpecification: Format checker for 'integer' format not found

Failed validating 'format' in schema:
    {'default': 1000,
     'format': 'integer',
     'nullable': False,
     'type': 'number'}

On instance:
    1000